### PR TITLE
Don't bump version in updater

### DIFF
--- a/.github/workflows/google-fonts.yml
+++ b/.github/workflows/google-fonts.yml
@@ -21,9 +21,6 @@ jobs:
       - name: Update fonts
         run: npm run update-fonts
 
-      - name: Update version
-        run: npm version patch
-
       - name: Push changes
         uses: devops-infra/action-commit-push@master
         with:


### PR DESCRIPTION
This is just going to spam versions. We don't need to do that.

If we need to bump versions, just do that manually.