### PR TITLE
Change plugin output name

### DIFF
--- a/.dev/install.mjs
+++ b/.dev/install.mjs
@@ -1,12 +1,11 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import pkg from '../package.json' assert { type: 'json' };
 
 function installWindows() {
   const appData = process.env.APPDATA;
   const pluginPath = path.join(appData, 'BetterDiscord', 'plugins');
-  const pluginName = pkg.name + '.plugin.js';
+  const pluginName = 'betterdiscord-google-fonts.plugin.js';
   const compiledPlugin = 'dist/' + pluginName;
 
   if (!fs.existsSync(compiledPlugin)) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -38,7 +38,7 @@ export default defineConfig(({ mode }) => ({
       external: ['react', 'react-dom', 'betterdiscord/bdapi'],
       inlineDynamicImports: true,
       output: {
-        entryFileNames: 'google-fonts.plugin.js',
+        entryFileNames: 'betterdiscord-google-fonts.plugin.js',
         format: 'commonjs',
         manualChunks: () => 'bundle.js',
       },


### PR DESCRIPTION
Rebuild of the plugin unintentionally changed plugin file name, which BetterDiscord plugin repository was not looking for.

This fixes the issue and should let BetterDiscord plugin repository pick up the new version.

Would resolve issue #22 